### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,8 @@ jobs:
   docs:
     name: Build Documentation
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python


### PR DESCRIPTION
Potential fix for [https://github.com/philipp-horstenkamp/auto_print/security/code-scanning/2](https://github.com/philipp-horstenkamp/auto_print/security/code-scanning/2)

To fix the issue, we will add a `permissions` block to the `docs` job, explicitly setting the permissions to `contents: read`. This ensures that the job has only the minimal permissions required to perform its tasks. The change will be made in the `.github/workflows/ci.yml` file, specifically within the `docs` job definition.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
