### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,6 +70,8 @@ jobs:
     needs: [test, docs]
     runs-on: windows-latest
     if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/master' || github.ref == 'refs/heads/dev'
+    permissions:
+      contents: read
     steps:
     - uses: actions/checkout@v4
     - name: Hello World


### PR DESCRIPTION
Potential fix for [https://github.com/philipp-horstenkamp/auto_print/security/code-scanning/3](https://github.com/philipp-horstenkamp/auto_print/security/code-scanning/3)

To fix the issue, we will add a `permissions` block to the "Build" job, explicitly setting the permissions to `contents: read`. This is the minimal permission required for most CI workflows and ensures that the job does not have unnecessary write access to the repository. The change will be made in the `.github/workflows/ci.yml` file under the "Build" job definition.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
