### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,8 @@ jobs:
   test:
     name: Test
     runs-on: windows-latest
+    permissions:
+      contents: read
     strategy:
       matrix:
         python-version: ['3.11', '3.12', '3.13']


### PR DESCRIPTION
Potential fix for [https://github.com/philipp-horstenkamp/auto_print/security/code-scanning/1](https://github.com/philipp-horstenkamp/auto_print/security/code-scanning/1)

To fix the issue, we need to add an explicit `permissions` block to the `test` job. Since the job only runs tests and does not require write access to the repository or other GitHub features, the minimal permission of `contents: read` is sufficient. This ensures that the job has only the permissions it needs and adheres to the principle of least privilege.

The `permissions` block should be added directly under the `test` job definition, on line 12, to limit the scope of the permissions to this specific job.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
