### PR TITLE
chore(workflows): add artifact-based release workflow and update CI triggers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,8 +2,15 @@ name: CI
 
 on:
   push:
+    branches:
+    - main
+    tags:
+    - v*                 # run CI when a version tag is pushed
+  pull_request:
+    types: [opened, reopened, synchronize]
+  workflow_dispatch:
   release:
-    types: [published]
+    types: [published]   # optional: run when a draft is published
 
 jobs:
 
@@ -154,7 +161,7 @@ jobs:
       pages: write
     steps:
     - name: Download documentation artifact
-      uses: actions/download-artifact@v5
+      uses: actions/download-artifact@v6
       with:
         name: documentation
         path: docs_html

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -161,7 +161,7 @@ jobs:
       pages: write
     steps:
     - name: Download documentation artifact
-      uses: actions/download-artifact@v6
+      uses: actions/download-artifact@v5
       with:
         name: documentation
         path: docs_html

--- a/.github/workflows/publish-from-artifacts.yml
+++ b/.github/workflows/publish-from-artifacts.yml
@@ -1,0 +1,54 @@
+name: Publish Release from CI Artifacts
+
+on:
+  workflow_run:
+    workflows: [CI]            # must match the workflow name in your repo
+    types: [completed]
+
+permissions:
+  contents: write
+  id-token: write
+  attestations: write
+
+jobs:
+  publish:
+    if: >
+      github.event.workflow_run.conclusion == 'success' &&
+      startsWith(github.event.workflow_run.ref, 'refs/tags/')
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Derive tag name
+      id: tag
+      run: |
+        REF='${{ github.event.workflow_run.ref }}'  # e.g., refs/tags/v2.0.0
+        echo "name=${REF#refs/tags/}" >> "$GITHUB_OUTPUT"
+
+    - name: Download wheel artifact (distribution-packages)
+      uses: actions/download-artifact@v6
+      with:
+          # Download artifacts from the triggering CI run:
+        run-id: ${{ github.event.workflow_run.id }}
+        name: distribution-packages
+        path: release_artifacts/wheel
+
+    - name: Download MSI artifact (MSI)
+      uses: actions/download-artifact@v6
+      with:
+        run-id: ${{ github.event.workflow_run.id }}
+        name: MSI
+        path: release_artifacts/msi
+
+    - name: List downloaded files (debug)
+      run: |
+        ls -lahR release_artifacts || true
+
+    - name: Upload assets to the tag's Release
+      uses: softprops/action-gh-release@v2
+      with:
+        tag_name: ${{ steps.tag.outputs.name }}
+        files: |
+          release_artifacts/wheel/**/*.whl
+          release_artifacts/msi/**/*.msi
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish-from-artifacts.yml
+++ b/.github/workflows/publish-from-artifacts.yml
@@ -33,7 +33,7 @@ jobs:
         path: release_artifacts/wheel
 
     - name: Download MSI artifact (MSI)
-      uses: actions/download-artifact@v6
+      uses: actions/download-artifact@v5
       with:
         run-id: ${{ github.event.workflow_run.id }}
         name: MSI

--- a/.github/workflows/publish-from-artifacts.yml
+++ b/.github/workflows/publish-from-artifacts.yml
@@ -25,7 +25,7 @@ jobs:
         echo "name=${REF#refs/tags/}" >> "$GITHUB_OUTPUT"
 
     - name: Download wheel artifact (distribution-packages)
-      uses: actions/download-artifact@v6
+      uses: actions/download-artifact@v5
       with:
           # Download artifacts from the triggering CI run:
         run-id: ${{ github.event.workflow_run.id }}


### PR DESCRIPTION
- Added `publish-from-artifacts.yml` workflow to enable artifact-based releases triggered by CI completion.
- Updated `ci.yml` to include tag-based builds and additional event triggers.